### PR TITLE
docs: mention pynvim requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Screenshots
 Installation
 ------------
 
+Note: requires [pynvim](https://github.com/neovim/pynvim) (see `:help pynvim`).
+
 This is complete configuration using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua


### PR DESCRIPTION
It seems that this plugin depends on `pynvim`, which wasn't mentioned anywhere. This PR mentions this in the README 🙂