### PR TITLE
Fixed extra bracket in r.lua

### DIFF
--- a/lua/luasnip_snippets/r.lua
+++ b/lua/luasnip_snippets/r.lua
@@ -52,7 +52,7 @@ FIELD_TYPES = [
 'logical',
 'matrix',
 'numeric',
-'vector']]]
+'vector']]
 }
 
 


### PR DESCRIPTION
Removed square bracket on line 55 of r.lua. This caused my nvim configuration to break when loading r files.